### PR TITLE
create a memory system for the first 3 bots and a way for each to do …

### DIFF
--- a/src/team3player/RobotPlayer.java
+++ b/src/team3player/RobotPlayer.java
@@ -3,6 +3,12 @@ import battlecode.common.*;
 
 public strictfp class RobotPlayer {
     static RobotController rc;
+    ///memory section
+    static MemoryForHQ HQMemory = null;
+    static MemoryForRefinery RefineryMemory = null;
+    static MemoryforMiner MinerMemory = null;
+    //simple var to control execution for first turn logic
+    static boolean firstTurn = true;
 
     static Direction[] directions = {
         Direction.NORTH,
@@ -63,13 +69,31 @@ public strictfp class RobotPlayer {
             }
         }
     }
+    static void MinerStartup() {
+        //please add any logic for is only executed on the bots first turn here
+        MinerMemory = new MemoryforMiner();
+        for (RobotInfo bot : rc.senseNearbyRobots(-1, rc.getTeam())) {
+            if (bot.getType() == RobotType.HQ) {
+                MinerMemory.HQ = bot.getLocation();
+            }
+        }
+    }
+
 
     static void runHQ() throws GameActionException {
+        if (firstTurn) {
+            firstTurn = false;
+            HQMemory = new MemoryForHQ();
+        }
         for (Direction dir : directions)
             tryBuild(RobotType.MINER, dir);
     }
 
     static void runMiner() throws GameActionException {
+        if (firstTurn) {
+            firstTurn = false;
+            MinerStartup();
+        }
         tryBlockchain();
         tryMove(randomDirection());
         if (tryMove(randomDirection()))
@@ -86,6 +110,10 @@ public strictfp class RobotPlayer {
     }
 
     static void runRefinery() throws GameActionException {
+        if (firstTurn) {
+            firstTurn = false;
+            RefineryMemory = new MemoryForRefinery();
+        }
         // System.out.println("Pollution: " + rc.sensePollution(rc.getLocation()));
     }
 
@@ -231,4 +259,13 @@ public strictfp class RobotPlayer {
         }
         // System.out.println(rc.getRoundMessages(turnCount-1));
     }
+}
+class MemoryForHQ {
+     int numOfMiners = 0;
+}
+class MemoryforMiner {
+     MapLocation HQ = null;
+}
+class MemoryForRefinery {
+
 }


### PR DESCRIPTION
I wrote a class to be a space to hold memory for each bot type and a simple boolean to track the first turn. That way the new memory is only created once on the first turn of the bots life. If anything doesn't make sense please deny this pull request and write which parts need to be improved. I ran code on my computer and it worked. No tests written sadly.